### PR TITLE
appdata: Use <url> for issues & translations

### DIFF
--- a/data/org.gustavoperedo.FontDownloader.appdata.xml.in
+++ b/data/org.gustavoperedo.FontDownloader.appdata.xml.in
@@ -8,8 +8,6 @@
   <description>
     <p>
 	  Have you ever wanted to change the font in your terminal, but didn't want to go through the entire process of searching, downloading and installing a font? This simple to use and adaptive GTK application allows you to search and install fonts directly from Google Fonts' website!
-    Want to contribute to the project as a translator? Join my project here: poeditor.com/join/project?hash=hfnXv8Iw4o
-    For suggestions and bug fixes open an issue at github.com/GustavoPeredo/Font-Downloader/ or e-mail me at gustavomperedo@protonmail.com.
     </p>
   </description>
   <screenshots>
@@ -228,6 +226,8 @@
     <release version="1.0.0" date="2020-09-16"/>
   </releases>
   <url type="homepage">https://github.com/GustavoPeredo/font-downloader</url>
+  <url type="bugtracker">https://github.com/GustavoPeredo/Font-Downloader/issues</url>
+  <url type="translate">https://poeditor.com/join/project?hash=hfnXv8Iw4o</url>
   <developer_name>Gustavo Peredo</developer_name>
   <launchable type="desktop-id">org.gustavoperedo.FontDownloader.desktop</launchable>
   <content_rating type="oars-1.1"/>


### PR DESCRIPTION
These URLs in the freeform text of <description> are not clickable in software centres like GNOME Software. These <url type=''> values are defined in https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url and are displayed together in Software.

There are other URL types defined in the AppStream spec, but I can't immediately see a help page, FAQ, or donation link.

The AppStream spec warns against using `mailto:` links in `<url>`.