### PR TITLE
build.yml: update workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,11 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-40
+      image: bilelmoussaoui/flatpak-github-actions:gnome-44
       options: --privileged
     steps:
-    - uses: actions/checkout@v2
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
+    - uses: actions/checkout@v3
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
       with:
         bundle: org.gustavoperedo.FontDownloader
         manifest-path: org.gustavoperedo.FontDownloader.Master.json


### PR DESCRIPTION
This PR fixes the node warning displayed under Annotations in Actions by bumping the `actions/checkout` version to v3. I have also updated the container image to GNOME 44 and the `flatpak-builder` version to v6.