### PR TITLE
Appdata related changes

### DIFF
--- a/data/org.gustavoperedo.FontDownloader.appdata.xml.in
+++ b/data/org.gustavoperedo.FontDownloader.appdata.xml.in
@@ -230,6 +230,9 @@
   <url type="bugtracker">https://github.com/GustavoPeredo/Font-Downloader/issues</url>
   <url type="translate">https://poeditor.com/join/project?hash=hfnXv8Iw4o</url>
   <developer_name>Gustavo Peredo</developer_name>
+  <developer id="io.github.gustavoperedo">
+    <name>Gustavo Peredo</name>
+  </developer>
   <launchable type="desktop-id">org.gustavoperedo.FontDownloader.desktop</launchable>
   <content_rating type="oars-1.1"/>
   <custom>

--- a/data/org.gustavoperedo.FontDownloader.appdata.xml.in
+++ b/data/org.gustavoperedo.FontDownloader.appdata.xml.in
@@ -226,6 +226,7 @@
     <release version="1.0.0" date="2020-09-16"/>
   </releases>
   <url type="homepage">https://github.com/GustavoPeredo/font-downloader</url>
+  <url type="vcs-browser">https://github.com/GustavoPeredo/font-downloader</url>
   <url type="bugtracker">https://github.com/GustavoPeredo/Font-Downloader/issues</url>
   <url type="translate">https://poeditor.com/join/project?hash=hfnXv8Iw4o</url>
   <developer_name>Gustavo Peredo</developer_name>

--- a/data/org.gustavoperedo.FontDownloader.appdata.xml.in
+++ b/data/org.gustavoperedo.FontDownloader.appdata.xml.in
@@ -232,7 +232,6 @@
   <launchable type="desktop-id">org.gustavoperedo.FontDownloader.desktop</launchable>
   <content_rating type="oars-1.1"/>
   <custom>
-    <value key="Purism::form_factor">workstation</value>
     <value key="Purism::form_factor">mobile</value>
   </custom>
 </component>

--- a/data/org.gustavoperedo.FontDownloader.appdata.xml.in
+++ b/data/org.gustavoperedo.FontDownloader.appdata.xml.in
@@ -26,7 +26,7 @@
   </screenshots>
   <releases>
     <release version="8.0.0" date="2021-8-29">
-      <description>
+      <description translate="no">
         <p>New on version 8.0.0:</p>
         <ul>
           <li>Updated app description</li>
@@ -37,28 +37,28 @@
       </description>
     </release>
     <release version="7.0.0" date="2021-7-17">
-      <description>
+      <description translate="no">
         <ul>
           <li> X11 fixes</li>
         </ul>
       </description>
     </release>
     <release version="6.0.0" date="2021-6-26">
-      <description>
+      <description translate="no">
         <ul>
           <li> Translations, fonts and code updated!</li>
         </ul>
       </description>
     </release>
     <release version="4.5.0" date="2021-5-5">
-      <description>
+      <description translate="no">
         <ul>
           <li> Updated fonts </li>
         </ul>
       </description>
     </release>
     <release version="4.3.0" date="2021-3-22">
-      <description>
+      <description translate="no">
         <ul>
           <li> Update all translations </li>
           <li> Updated fonts </li>
@@ -66,7 +66,7 @@
       </description>
     </release>
     <release version="4.2.1" date="2021-2-20">
-      <description>
+      <description translate="no">
         <ul>
           <li> Created a workaround for the following error: [xcb] Unknown sequence number while processing queue </li>
           <li> Updated fonts </li>
@@ -75,7 +75,7 @@
       </description>
     </release>
     <release version="4.2.0" date="2021-2-20">
-      <description>
+      <description translate="no">
         <ul>
           <li> Bug fixes </li>
           <li> Updated fonts </li>
@@ -84,7 +84,7 @@
       </description>
     </release>
     <release version="4.1.2" date="2021-1-6">
-      <description>
+      <description translate="no">
         <ul>
           <li> Bug fixes </li>
           <li> Implemented version control </li>
@@ -93,7 +93,7 @@
       </description>
     </release>
     <release version="4.1.1" date="2020-12-31">
-      <description>
+      <description translate="no">
         <ul>
           <li> Fixed many bugs </li>
           <li> Added loading screens and bars </li>
@@ -102,7 +102,7 @@
       </description>
     </release>
     <release version="4.1.0" date="2020-12-25">
-      <description>
+      <description translate="no">
         <ul>
           <li> Lot's of updated translations </li>
           <li> Christmas icon only on about section </li>
@@ -111,7 +111,7 @@
       </description>
     </release>
     <release version="3.12.1" date="2020-12-5">
-      <description>
+      <description translate="no">
         <p> Version 3.12.1 </p>
         <ul>
           <li> Translation Updates </li>
@@ -124,7 +124,7 @@
       </description>
     </release>
     <release version="3.12.0" date="2020-11-25">
-      <description>
+      <description translate="no">
         <p> Version 3.12.0 </p>
         <ul>
           <li> Translation Updates </li>
@@ -145,7 +145,7 @@
       </description>
     </release>
     <release version="3.11.0" date="2020-10-25">
-      <description>
+      <description translate="no">
         <p> Version 3.11.0 </p>
         <p> Improved russian translation</p>
         <p> Fixed portuguese application name </p>
@@ -163,7 +163,7 @@
       </description>
     </release>
     <release version="3.10.2" date="2020-10-6">
-      <description>
+      <description translate="no">
         <p> Version 3.10.2 </p>
         <p> Updated translations</p>
         <p> Version 3.0.0 </p>
@@ -179,12 +179,12 @@
       </description>
     </release>
     <release version="3.10.1" date="2020-10-4">
-      <description>
+      <description translate="no">
         <p> Important bug fix, where if user didn't have .local/share/fonts folder, the app wouldn't start</p>
       </description>
     </release>
     <release version="3.10.0" date="2020-10-4">
-      <description>
+      <description translate="no">
         <p> Fixes:</p>
         <ul>
           <li> Russian translation should now work </li>
@@ -194,7 +194,7 @@
       </description>
     </release>
     <release version="3.0.0" date="2020-10-02">
-      <description>
+      <description translate="no">
         <p>This release aims to be the last feature release:</p>
         <ul>
           <li>Dark mode!</li>
@@ -207,12 +207,12 @@
       </description>
     </release>
     <release version="2.0.1" date="2020-10-01">
-      <description>
+      <description translate="no">
         <p>Fixes Spanish translation</p>
       </description>
     </release>
     <release version="2.0.0" date="2020-09-30">
-      <description>
+      <description translate="no">
         <p>This release brings major improvements:</p>
         <ul>
           <li>Better resource usage</li>


### PR DESCRIPTION
### appdata: Mark release descriptions as untranslatable

GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.

### appdata: Remove one of purism tag

Remove one of purism tag to pass appstreamcli validation

### appdata: Add vcs-browser URL

This link useful for the application centers like GNOME Software.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url

### appdata: Add developer ID]

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer