### PR TITLE
fix: remove deprecated tags

### DIFF
--- a/data/org.gustavoperedo.FontDownloader.appdata.xml.in
+++ b/data/org.gustavoperedo.FontDownloader.appdata.xml.in
@@ -231,8 +231,4 @@
   <developer_name>Gustavo Peredo</developer_name>
   <launchable type="desktop-id">org.gustavoperedo.FontDownloader.desktop</launchable>
   <content_rating type="oars-1.1"/>
-  <custom>
-    <value key="Purism::form_factor">workstation</value>
-    <value key="Purism::form_factor">mobile</value>
-  </custom>
 </component>


### PR DESCRIPTION
Purism tags are deprecated see:
https://github.com/ximion/appstream/issues/476
These tags cause the following build failure: https://buildbot.flathub.org/#/builders/37/builds/15360 which prevents bumping the gnome runtime in https://github.com/flathub/org.gustavoperedo.FontDownloader/pull/11